### PR TITLE
add some test for admins

### DIFF
--- a/spec/controllers/administration/items_controller_spec.rb
+++ b/spec/controllers/administration/items_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+module Administration
+  RSpec.describe ItemsController, type: :controller do
+    describe "visitor access forbidden" do
+      it { expect(get(:index)).to have_http_status(:found) }
+      it { expect(get(:new)).to have_http_status(:found) }
+    end
+
+    describe "user access forbidden" do
+      before { sign_in FactoryBot.create(:user) }
+
+      it { expect(get(:index)).to have_http_status(:found) }
+      it { expect(get(:new)).to have_http_status(:found) }
+    end
+
+    describe "admin access" do
+      before { sign_in FactoryBot.create(:admin) }
+
+      it { expect(get(:index)).to have_http_status(:success) }
+      it { expect(get(:new)).to have_http_status(:success) }
+    end
+  end
+end

--- a/spec/controllers/admins/registration_controller_spec.rb
+++ b/spec/controllers/admins/registration_controller_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+module Admins
+  RSpec.describe RegistrationsController, type: :controller do
+    before { @request.env["devise.mapping"] = Devise.mappings[:admin] }
+
+    describe "visitor can't sign_up" do
+      it "return http found" do
+        get :new
+        expect(response).to have_http_status(:found)
+      end
+
+      it "redirect_to" do
+        get :new
+        expect(response).to redirect_to root_path
+      end
+    end
+  end
+end


### PR DESCRIPTION
test pour vérifier que la page sign up de l'admin n'est pas accessible et qu'elle redirige bien vers la page d'accueil.

Autres tests sur le controlleur items de la partie admin pour vérifier que ces pages ne sont pas accessibles par l'utilisateur. test non exhaustifs. Je continue à en faire d'autres 